### PR TITLE
feat: create short URL with hash and collision detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module url-short
 
 go 1.22.3
+
+require github.com/lib/pq v1.10.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/handlers.go
+++ b/handlers.go
@@ -1,11 +1,22 @@
 package main
 
-import "net/http"
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"url-short/internal/database"
+)
 
-type apiConfig struct{}
+type apiConfig struct{
+	DB *database.Queries
+}
 
 type HealthResponse struct {
 	Status string `json:"status"`
+}
+
+type POSTLongURLRequest struct {
+	LongURL string `json:"status"`
 }
 
 func (apiCfg *apiConfig) healthz(w http.ResponseWriter, r *http.Request) {
@@ -14,4 +25,24 @@ func (apiCfg *apiConfig) healthz(w http.ResponseWriter, r *http.Request) {
 	}
 
 	respondWithJSON(w, http.StatusOK, payload)
+}
+
+func (apiCfg *apiConfig) POSTLongURL(w http.ResponseWriter, r *http.Request) {
+	payload := POSTLongURLRequest{}
+
+	err := json.NewDecoder(r.Body).Decode(&payload)
+
+	if err != nil {
+		respondWithError(w, 400, "incorrect request fromat")
+		return
+	}
+
+	url, err := url.ParseRequestURI(payload.LongURL)
+
+	if err != nil {
+		respondWithError(w, 400, "could not parse request URL")
+		return
+	}
+	
+	shortURL, err :=apiCfg.DB.CreateURL()	
 }

--- a/handlers.go
+++ b/handlers.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/url"
+	"time"
+
 	"url-short/internal/database"
+	"url-short/internal/shortener"
 )
 
-type apiConfig struct{
+type apiConfig struct {
 	DB *database.Queries
 }
 
@@ -16,18 +22,22 @@ type HealthResponse struct {
 }
 
 type POSTLongURLRequest struct {
-	LongURL string `json:"status"`
+	LongURL string `json:"long_url"`
+}
+
+type POSTLongURLResponse struct {
+	ShortURL string `json:"short_url"`
 }
 
 func (apiCfg *apiConfig) healthz(w http.ResponseWriter, r *http.Request) {
-	payload := HealthResponse {
+	payload := HealthResponse{
 		Status: "ok",
 	}
 
 	respondWithJSON(w, http.StatusOK, payload)
 }
 
-func (apiCfg *apiConfig) POSTLongURL(w http.ResponseWriter, r *http.Request) {
+func (apiCfg *apiConfig) postLongURL(w http.ResponseWriter, r *http.Request) {
 	payload := POSTLongURLRequest{}
 
 	err := json.NewDecoder(r.Body).Decode(&payload)
@@ -40,9 +50,52 @@ func (apiCfg *apiConfig) POSTLongURL(w http.ResponseWriter, r *http.Request) {
 	url, err := url.ParseRequestURI(payload.LongURL)
 
 	if err != nil {
+		log.Println(err)
 		respondWithError(w, 400, "could not parse request URL")
 		return
 	}
-	
-	shortURL, err :=apiCfg.DB.CreateURL()	
+
+	shortURLHash, err := hashCollisionDetection(apiCfg.DB, url.String(), 1, r.Context())
+
+	if err != nil {
+		log.Println(err)
+		respondWithError(w, 500, "could not resolve hash collision")
+	}
+
+	now := time.Now()
+	shortenedURL, err := apiCfg.DB.CreateURL(r.Context(), database.CreateURLParams{
+		LongUrl:   url.String(),
+		ShortUrl:  shortURLHash,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	if err != nil {
+		log.Println(err)
+		respondWithError(w, 500, "could not create short URL in database")
+		return
+	}
+
+	respondWithJSON(w, 201, POSTLongURLResponse{
+		ShortURL: shortenedURL.ShortUrl,
+	})
+}
+
+func hashCollisionDetection(DB *database.Queries, url string, count int, requestContext context.Context) (string, error) {
+	hashURL := shortener.Hash(url, count)
+	shortURLHash := shortener.Shorten(hashURL)
+
+	_, err := DB.SelectURL(requestContext, shortURLHash)
+
+	if err == sql.ErrNoRows {
+		return shortURLHash, nil
+	}
+
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	count++
+
+	return hashCollisionDetection(DB, url, count, requestContext)
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-func TestHealthEndpoint(t *testing.T){
-	t.Run("test healthz endpoint", func(t *testing.T){
+func TestHealthEndpoint(t *testing.T) {
+	t.Run("test healthz endpoint", func(t *testing.T) {
 		request, _ := http.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
 		response := httptest.NewRecorder()
 
@@ -22,7 +22,7 @@ func TestHealthEndpoint(t *testing.T){
 		if err != nil {
 			t.Errorf("unable to parse response %q into %q", response.Body, got)
 		}
-		
+
 		if got.Status != "ok" {
 			t.Errorf("status field must be okay on health response got %q wanted %q", got.Status, "ok")
 		}

--- a/httphelper.go
+++ b/httphelper.go
@@ -10,7 +10,7 @@ func respondWithJSON(w http.ResponseWriter, status int, payload interface{}) {
 	data, err := json.Marshal(payload)
 
 	if err != nil {
-		log.Printf("can not Marshal payload %v", payload)
+		log.Printf("can not marshal payload %v", payload)
 		return
 	}
 

--- a/internal/shortener/main.go
+++ b/internal/shortener/main.go
@@ -8,19 +8,15 @@ import (
 
 const urlHashPostfix = "Xa1"
 
-func hash(inputString string, withPostfix bool, postfixCount int) string {
+func Hash(inputString string, postfixCount int) string {
 	var hash [16]byte
 
-	if withPostfix {
-		hash = md5.Sum([]byte(inputString + strings.Repeat(urlHashPostfix, postfixCount)))
-	} else {
-		hash = md5.Sum([]byte(inputString))
-	}
+	hash = md5.Sum([]byte(inputString + strings.Repeat(urlHashPostfix, postfixCount)))
 
 	return hex.EncodeToString(hash[:])
 }
 
-func shorten(hashToShorten string) string {
+func Shorten(hashToShorten string) string {
 	if len(hashToShorten) < 8 {
 		return hashToShorten
 	}

--- a/internal/shortener/main.go
+++ b/internal/shortener/main.go
@@ -1,0 +1,29 @@
+package shortener
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+)
+
+const urlHashPostfix = "Xa1"
+
+func hash(inputString string, withPostfix bool, postfixCount int) string {
+	var hash [16]byte
+
+	if withPostfix {
+		hash = md5.Sum([]byte(inputString + strings.Repeat(urlHashPostfix, postfixCount)))
+	} else {
+		hash = md5.Sum([]byte(inputString))
+	}
+
+	return hex.EncodeToString(hash[:])
+}
+
+func shorten(hashToShorten string) string {
+	if len(hashToShorten) < 8 {
+		return hashToShorten
+	}
+
+	return hashToShorten[:7]
+}

--- a/internal/shortener/main_test.go
+++ b/internal/shortener/main_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 )
 
-func TestHash(t *testing.T){
+func TestHash(t *testing.T) {
 	url := "www.test.com/shop"
 
-	t.Run("test URL hash with no collision ", func(t *testing.T){
-		got := hash(url, false, 0)
+	t.Run("test URL hash with no collision", func(t *testing.T) {
+		got := Hash(url, 0)
 		hash := md5.Sum([]byte(url))
 		want := hex.EncodeToString(hash[:])
 
@@ -19,23 +19,23 @@ func TestHash(t *testing.T){
 		}
 	})
 
-	t.Run("test URL hash with collision", func(t *testing.T){
-		got := hash(url, true, 1)
+	t.Run("test URL hash with collision", func(t *testing.T) {
+		got := Hash(url, 1)
 		hash := md5.Sum([]byte(url + urlHashPostfix))
 		want := hex.EncodeToString(hash[:])
 
 		if got != want {
 			t.Errorf("got %q, want %q, given %q", got, want, url)
 		}
-	})	
+	})
 }
 
-func TestShort(t *testing.T){
+func TestShort(t *testing.T) {
 	hashLong := "asdfghjkl"
 	shortHash := "xa1"
 
-	t.Run("test hash shoren with large hash", func(t *testing.T){
-		got := shorten(hashLong)
+	t.Run("test hash shoren with large hash", func(t *testing.T) {
+		got := Shorten(hashLong)
 		want := hashLong[:7]
 
 		if got != want {
@@ -43,8 +43,8 @@ func TestShort(t *testing.T){
 		}
 	})
 
-	t.Run("test hash with short hash", func(t *testing.T){
-		got := shorten(shortHash)
+	t.Run("test hash with short hash", func(t *testing.T) {
+		got := Shorten(shortHash)
 		want := shortHash
 
 		if got != want {
@@ -52,4 +52,3 @@ func TestShort(t *testing.T){
 		}
 	})
 }
-

--- a/internal/shortener/main_test.go
+++ b/internal/shortener/main_test.go
@@ -1,0 +1,55 @@
+package shortener
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"testing"
+)
+
+func TestHash(t *testing.T){
+	url := "www.test.com/shop"
+
+	t.Run("test URL hash with no collision ", func(t *testing.T){
+		got := hash(url, false, 0)
+		hash := md5.Sum([]byte(url))
+		want := hex.EncodeToString(hash[:])
+
+		if got != want {
+			t.Errorf("got %q, wanted %q given %q", got, want, url)
+		}
+	})
+
+	t.Run("test URL hash with collision", func(t *testing.T){
+		got := hash(url, true, 1)
+		hash := md5.Sum([]byte(url + urlHashPostfix))
+		want := hex.EncodeToString(hash[:])
+
+		if got != want {
+			t.Errorf("got %q, want %q, given %q", got, want, url)
+		}
+	})	
+}
+
+func TestShort(t *testing.T){
+	hashLong := "asdfghjkl"
+	shortHash := "xa1"
+
+	t.Run("test hash shoren with large hash", func(t *testing.T){
+		got := shorten(hashLong)
+		want := hashLong[:7]
+
+		if got != want {
+			t.Errorf("got %q, wanted %q, given %q", got, want, hashLong)
+		}
+	})
+
+	t.Run("test hash with short hash", func(t *testing.T){
+		got := shorten(shortHash)
+		want := shortHash
+
+		if got != want {
+			t.Errorf("got %q, want %q, given %q", got, want, shortHash)
+		}
+	})
+}
+

--- a/main.go
+++ b/main.go
@@ -4,10 +4,21 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"database/sql"
+	"url-short/internal/database"
 )
 
 func main() {
 	serverPort := os.Getenv("SERVER_PORT")
+	dbURL := os.Getenv("PG_CONN")
+
+	db, err := sql.Open("postgres", dbURL)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dbQueries := database.New(db)
 
 	mux := http.NewServeMux()
 
@@ -16,9 +27,12 @@ func main() {
 		Handler: mux,
 	}
 
-	apiCfg := apiConfig{}
+	apiCfg := apiConfig{
+		DB: dbQueries,
+	}
 
 	mux.HandleFunc("GET /api/v1/healthz", apiCfg.healthz)
+	mux.HandleFunc("POST /api/v1/data/shorten", apiCfg.POSTLongURL)
 
 	log.Printf("Serving port : %v \n", serverPort)
 	log.Fatal(server.ListenAndServe())

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"database/sql"
 	"log"
 	"net/http"
 	"os"
-	"database/sql"
 	"url-short/internal/database"
+
+	_ "github.com/lib/pq"
 )
 
 func main() {
@@ -32,7 +34,7 @@ func main() {
 	}
 
 	mux.HandleFunc("GET /api/v1/healthz", apiCfg.healthz)
-	mux.HandleFunc("POST /api/v1/data/shorten", apiCfg.POSTLongURL)
+	mux.HandleFunc("POST /api/v1/data/shorten", apiCfg.postLongURL)
 
 	log.Printf("Serving port : %v \n", serverPort)
 	log.Fatal(server.ListenAndServe())

--- a/sql/schema/001_urls.sql
+++ b/sql/schema/001_urls.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 CREATE TABLE urls (
-		id integer PRIMARY KEY,
+		id SERIAL PRIMARY KEY,
 		short_url VARCHAR(100) UNIQUE NOT NULL,
 		long_url VARCHAR(300) UNIQUE NOT NULL,
 		created_at TIMESTAMP NOT NULL,

--- a/sql/schema/001_urls.sql
+++ b/sql/schema/001_urls.sql
@@ -1,6 +1,6 @@
 -- +goose Up
 CREATE TABLE urls (
-		id SERIAL PRIMARY KEY,
+		id integer PRIMARY KEY,
 		short_url VARCHAR(100) UNIQUE NOT NULL,
 		long_url VARCHAR(300) UNIQUE NOT NULL,
 		created_at TIMESTAMP NOT NULL,


### PR DESCRIPTION
Functionality to turn a long URL to a short URL and persist that in our postgres instance this is done with an MD5 hash of the original URL then using collision detection to ensure the short URL is unique. 