### PR TITLE
feat: add authenticated URL delete endpoint

### DIFF
--- a/collision.go
+++ b/collision.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+
+	"url-short/internal/database"
+	"url-short/internal/shortener"
+)
+
+func hashCollisionDetection(DB *database.Queries, url string, count int, requestContext context.Context) (string, error) {
+	hashURL := shortener.Hash(url, count)
+	shortURLHash := shortener.Shorten(hashURL)
+
+	_, err := DB.SelectURL(requestContext, shortURLHash)
+
+	if err == sql.ErrNoRows {
+		return shortURLHash, nil
+	}
+
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	count++
+
+	return hashCollisionDetection(DB, url, count, requestContext)
+}

--- a/internal/database/urls.sql.go
+++ b/internal/database/urls.sql.go
@@ -44,6 +44,22 @@ func (q *Queries) CreateURL(ctx context.Context, arg CreateURLParams) (Url, erro
 	return i, err
 }
 
+const deleteURL = `-- name: DeleteURL :exec
+DELETE FROM urls
+WHERE user_id = $1 AND 
+short_url = $2
+`
+
+type DeleteURLParams struct {
+	UserID   int32
+	ShortUrl string
+}
+
+func (q *Queries) DeleteURL(ctx context.Context, arg DeleteURLParams) error {
+	_, err := q.db.ExecContext(ctx, deleteURL, arg.UserID, arg.ShortUrl)
+	return err
+}
+
 const selectURL = `-- name: SelectURL :one
 SELECT id, short_url, long_url, created_at, updated_at, user_id 
 FROM urls

--- a/internal/database/urls.sql.go
+++ b/internal/database/urls.sql.go
@@ -79,3 +79,21 @@ func (q *Queries) SelectURL(ctx context.Context, shortUrl string) (Url, error) {
 	)
 	return i, err
 }
+
+const updateShortURL = `-- name: UpdateShortURL :exec
+UPDATE urls
+SET long_url = $1
+WHERE user_id = $2 AND 
+short_url = $3
+`
+
+type UpdateShortURLParams struct {
+	LongUrl  string
+	UserID   int32
+	ShortUrl string
+}
+
+func (q *Queries) UpdateShortURL(ctx context.Context, arg UpdateShortURLParams) error {
+	_, err := q.db.ExecContext(ctx, updateShortURL, arg.LongUrl, arg.UserID, arg.ShortUrl)
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,8 @@ func main() {
 	// url management endpoints
 	mux.HandleFunc("POST /api/v1/data/shorten", apiCfg.authenticationMiddlewear(apiCfg.postLongURL))
 	mux.HandleFunc("GET /api/v1/{shortUrl}", apiCfg.getShortURL)
+	mux.HandleFunc("DELETE /api/v1/{shortUrl}", apiCfg.authenticationMiddlewear(apiCfg.deleteShortURL))
+
 
 	// user management endpoints
 	mux.HandleFunc("POST /api/v1/users", apiCfg.postAPIUsers)

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	mux.HandleFunc("POST /api/v1/data/shorten", apiCfg.authenticationMiddlewear(apiCfg.postLongURL))
 	mux.HandleFunc("GET /api/v1/{shortUrl}", apiCfg.getShortURL)
 	mux.HandleFunc("DELETE /api/v1/{shortUrl}", apiCfg.authenticationMiddlewear(apiCfg.deleteShortURL))
-
+	mux.HandleFunc("PUT /api/v1/{shortUrl}", apiCfg.authenticationMiddlewear(apiCfg.putShortURL))
 
 	// user management endpoints
 	mux.HandleFunc("POST /api/v1/users", apiCfg.postAPIUsers)

--- a/sql/queries/urls.sql
+++ b/sql/queries/urls.sql
@@ -12,3 +12,9 @@ WHERE short_url = $1;
 DELETE FROM urls
 WHERE user_id = $1 AND 
 short_url = $2;
+
+-- name: UpdateShortURL :exec
+UPDATE urls
+SET long_url = $1
+WHERE user_id = $2 AND 
+short_url = $3;

--- a/sql/queries/urls.sql
+++ b/sql/queries/urls.sql
@@ -7,3 +7,8 @@ RETURNING *;
 SELECT * 
 FROM urls
 WHERE short_url = $1;
+
+-- name: DeleteURL :exec
+DELETE FROM urls
+WHERE user_id = $1 AND 
+short_url = $2;

--- a/sql/schema/004_url_long_not_unique.sql
+++ b/sql/schema/004_url_long_not_unique.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+ALTER TABLE urls
+DROP CONSTRAINT urls_long_url_key;
+
+-- +goose Down
+ALTER TABLE urls
+ADD CONSTRAINT urls_long_url_key
+	UNIQUE (long_url)


### PR DESCRIPTION
This PR adds:
- A delete endpoint that requires authentication so users can delete their own URLs.
- A update endpioint so users can alter short URLs to point to a new long URL.