### PR TITLE
refactor: move user management REST handlers into distinct package

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -240,43 +240,6 @@ func (apiCfg *apiConfig) putShortURL(w http.ResponseWriter, r *http.Request, use
 	})
 }
 
-func (apiCfg *apiConfig) postAPIUsers(w http.ResponseWriter, r *http.Request) {
-	payload := APIUserRequest{}
-
-	err := json.NewDecoder(r.Body).Decode(&payload)
-
-	if err != nil {
-		log.Println(err)
-		respondWithError(w, http.StatusBadRequest, "could not parse request")
-		return
-	}
-
-	domainUser, err := user.NewUser(payload.Email, payload.Password)
-
-	if err != nil {
-		log.Println(err)
-		respondWithError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	user, err := apiCfg.DB.CreateUser(r.Context(), database.CreateUserParams{
-		Email:     domainUser.Email(),
-		Password:  domainUser.PasswordHash(),
-		CreatedAt: domainUser.CreatedAt(),
-		UpdatedAt: domainUser.UpdatedAt(),
-	})
-
-	if err != nil {
-		log.Println(err)
-		respondWithError(w, http.StatusInternalServerError, "could not create user in database")
-	}
-
-	respondWithJSON(w, http.StatusCreated, APIUserResponseNoToken{
-		ID:    user.ID,
-		Email: user.Email,
-	})
-}
-
 func (apiCfg *apiConfig) postAPILogin(w http.ResponseWriter, r *http.Request) {
 	payload := APIUserRequest{}
 

--- a/internal/api/main.go
+++ b/internal/api/main.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"github.com/redis/go-redis/v9"
+	"url-short/internal/database"
+)
+
+type APIConfig struct {
+	DB        *database.Queries
+	Cache     *redis.Client
+	JWTSecret string
+}
+
+func NewAPIConfig(db *database.Queries, cache *redis.Client, jwtSecret string) *APIConfig {
+	return &APIConfig{
+		DB:        db,
+		Cache:     cache,
+		JWTSecret: jwtSecret,
+	}
+}

--- a/internal/transport/http/helper/main.go
+++ b/internal/transport/http/helper/main.go
@@ -1,0 +1,36 @@
+package helper
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func RespondWithJSON(w http.ResponseWriter, status int, payload interface{}) {
+	data, err := json.Marshal(payload)
+
+	if err != nil {
+		log.Printf("can not marshal payload %v", payload)
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(status)
+	_, err = w.Write(data)
+
+	if err != nil {
+		log.Println("could not write data to response writer")
+	}
+}
+
+func RespondWithError(w http.ResponseWriter, code int, msg string) {
+	errorResponse := errorResponse{
+		Error: msg,
+	}
+
+	RespondWithJSON(w, code, errorResponse)
+}

--- a/internal/transport/http/helper/main_test.go
+++ b/internal/transport/http/helper/main_test.go
@@ -1,0 +1,56 @@
+package helper
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRespondWithJSON(t *testing.T) {
+	t.Run("test respond with json with generic interface", func(t *testing.T) {
+		response := httptest.NewRecorder()
+
+		type FooStruct struct {
+			Foo string `json:"foo"`
+		}
+
+		testStruct := FooStruct{
+			Foo: "bar",
+		}
+
+		RespondWithJSON(response, http.StatusOK, testStruct)
+
+		wantStruct := FooStruct{}
+
+		err := json.NewDecoder(response.Body).Decode(&wantStruct)
+
+		if err != nil {
+			t.Errorf("could not parse result as expected")
+		}
+
+		if testStruct != wantStruct {
+			t.Errorf("failed to respond with arbitrary interface got %q want %q", testStruct, wantStruct)
+		}
+	})
+}
+
+func TestRespondWithError(t *testing.T) {
+	t.Run("test respond with error with generic error", func(t *testing.T) {
+		response := httptest.NewRecorder()
+
+		RespondWithError(response, http.StatusInternalServerError, "stuff is broken")
+
+		wantStruct := errorResponse{}
+
+		err := json.NewDecoder(response.Body).Decode(&wantStruct)
+
+		if err != nil {
+			t.Errorf("could not parse result as expected")
+		}
+
+		if wantStruct.Error != "stuff is broken" {
+			t.Errorf("failed to respond with a generic error")
+		}
+	})
+}

--- a/internal/transport/http/users/main.go
+++ b/internal/transport/http/users/main.go
@@ -1,0 +1,69 @@
+package users
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"url-short/internal/api"
+	"url-short/internal/database"
+	"url-short/internal/domain/user"
+	"url-short/internal/transport/http/helper"
+)
+
+type handler struct {
+	// temporary now to allow transport, service and repository layers to be decoupled
+	apiCfg *api.APIConfig
+}
+
+func NewUserHandler(apiConfig *api.APIConfig) *handler {
+	return &handler{
+		apiCfg: apiConfig,
+	}
+}
+
+type CreateUserHTTPRequestBody struct {
+	Email    string `json:"email"`
+	Password string `json:"Password"`
+}
+
+type CreateUserHTTPResponseBody struct {
+	ID    int32  `json:"id"`
+	Email string `json:"email"`
+}
+
+func (handler *handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	payload := &CreateUserHTTPRequestBody{}
+
+	err := json.NewDecoder(r.Body).Decode(&payload)
+	if err != nil {
+		log.Println(err)
+		helper.RespondWithError(w, http.StatusBadRequest, "could not parse request")
+		return
+	}
+
+	domainUser, err := user.NewUser(payload.Email, payload.Password)
+
+	if err != nil {
+		log.Println(err)
+		helper.RespondWithError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	user, err := handler.apiCfg.DB.CreateUser(r.Context(), database.CreateUserParams{
+		Email:     domainUser.Email(),
+		Password:  domainUser.PasswordHash(),
+		CreatedAt: domainUser.CreatedAt(),
+		UpdatedAt: domainUser.UpdatedAt(),
+	})
+
+	if err != nil {
+		log.Println(err)
+		helper.RespondWithError(w, http.StatusInternalServerError, "could not create user in database")
+	}
+
+	helper.RespondWithJSON(w, http.StatusCreated, CreateUserHTTPResponseBody{
+		ID:    user.ID,
+		Email: user.Email,
+	})
+}


### PR DESCRIPTION
This PR attempts to move all of the user management REST endpoints into their own package. Currently the package will depend on an API config to pass arround the database connection, redis connection and JWT secret. This is not the end state but allows me to pull the API layer out into its own package. In the end state the API layer will not depend on a database connection. 

This PR also renames `postAPIUsers` 🤮  to `CreateUser` I have no idea what I was thinking there 🙄 