### PR TITLE
refactor: move refresh handler to user api layer package

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -389,21 +389,19 @@ func TestRefreshEndpoint(t *testing.T) {
 
 	dbQueries := database.New(db)
 
-	apiCfg := apiConfig{
+	apiCfg := api.APIConfig{
 		DB: dbQueries,
 	}
 
-	userAPICfg := api.APIConfig{
-		DB: dbQueries,
-	}
+	userHandler := users.NewUserHandler(&apiCfg)
 
-	_, err = setupUserOne(&userAPICfg)
+	_, err = setupUserOne(&apiCfg)
 
 	if err != nil {
 		t.Errorf("can not set up user for test case with err %q", err)
 	}
 
-	userOne, err := loginUserOne(&userAPICfg)
+	userOne, err := loginUserOne(&apiCfg)
 
 	if err != nil {
 		t.Errorf("can not login user one for test case with err %q", err)
@@ -417,9 +415,9 @@ func TestRefreshEndpoint(t *testing.T) {
 
 		refreshResponse := httptest.NewRecorder()
 
-		apiCfg.postAPIRefresh(refreshResponse, refreshRequest)
+		userHandler.RefreshAccessToken(refreshResponse, refreshRequest)
 
-		refreshGot := APIUsersRefreshResponse{}
+		refreshGot := users.RefreshAccessTokenHTTPResponse{}
 
 		err = json.NewDecoder(refreshResponse.Body).Decode(&refreshGot)
 
@@ -427,8 +425,8 @@ func TestRefreshEndpoint(t *testing.T) {
 			t.Error("could not decode refreshResponse")
 		}
 
-		if refreshGot.Token == "" {
-			t.Errorf("no token was returned from refresh endpoint got %q", refreshGot.Token)
+		if refreshGot.AccessToken == "" {
+			t.Errorf("no token was returned from refresh endpoint got %q", refreshGot.AccessToken)
 		}
 	})
 }

--- a/internal/transport/http/auth/main.go
+++ b/internal/transport/http/auth/main.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"url-short/internal/api"
+	"url-short/internal/database"
+	"url-short/internal/transport/http/helper"
+)
+
+type handler struct {
+	// temporary now to allow transport, service and repository layers to be decoupled
+	apiCfg *api.APIConfig
+}
+
+func NewAuthHandler(apiConfig *api.APIConfig) *handler {
+	return &handler{
+		apiCfg: apiConfig,
+	}
+}
+
+func ExtractAuthTokenFromRequest(r *http.Request) (string, error) {
+	authHeader := r.Header.Get("Authorization")
+
+	if authHeader == "" {
+		return "", errors.New("no authorization header supplied")
+	}
+
+	splitAuth := strings.Split(authHeader, " ")
+
+	if len(splitAuth) == 0 {
+		return "", errors.New("empty authorization header")
+	}
+
+	if len(splitAuth) != 2 && splitAuth[0] != "Bearer" {
+		return "", errors.New("invalid data in authorization header")
+	}
+
+	return splitAuth[1], nil
+}
+
+type authedHandeler func(http.ResponseWriter, *http.Request, database.User)
+
+func (handler *handler) AuthenticationMiddleware(nextHandler authedHandeler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestToken, err := ExtractAuthTokenFromRequest(r)
+
+		if err != nil {
+			helper.RespondWithError(w, http.StatusUnauthorized, err.Error())
+			return
+		}
+
+		claims := jwt.RegisteredClaims{}
+
+		token, err := jwt.ParseWithClaims(
+			requestToken,
+			&claims,
+			func(token *jwt.Token) (any, error) { return []byte(handler.apiCfg.JWTSecret), nil },
+		)
+
+		if err != nil {
+			helper.RespondWithError(w, http.StatusUnauthorized, "invalid jwt")
+			return
+		}
+
+		issuer, err := token.Claims.GetIssuer()
+
+		if err != nil {
+			helper.RespondWithError(w, http.StatusUnauthorized, "invalid jwt issuer")
+			return
+		}
+
+		if issuer != "url-short-auth" {
+			helper.RespondWithError(w, http.StatusUnauthorized, "invalid jwt issuer")
+			return
+		}
+
+		userID, err := token.Claims.GetSubject()
+
+		if err != nil {
+			helper.RespondWithError(w, http.StatusUnauthorized, "could not get subject from jwt")
+			return
+		}
+
+		userIDStr, err := strconv.Atoi(userID)
+
+		if err != nil {
+			helper.RespondWithError(w, http.StatusUnauthorized, "invalid jwt subject")
+		}
+
+		user, err := handler.apiCfg.DB.SelectUserByID(r.Context(), int32(userIDStr))
+
+		if err != nil {
+			log.Println(err)
+			helper.RespondWithError(w, http.StatusUnauthorized, "could not find user in database")
+		}
+
+		nextHandler(w, r, user)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -52,9 +52,9 @@ func main() {
 	}
 
 	// allow us to only refactor the user endpoints for now
-	userAPICfg := api.NewAPIConfig(dbQueries, redisClient, jwtSecret)
+	newAPICfg := api.NewAPIConfig(dbQueries, redisClient, jwtSecret)
 
-	userHandler := users.NewUserHandler(userAPICfg)
+	userHandler := users.NewUserHandler(newAPICfg)
 
 	// utility endpoints
 	mux.HandleFunc("GET /api/v1/healthz", apiCfg.healthz)
@@ -92,7 +92,7 @@ func main() {
 	)
 	mux.HandleFunc(
 		"POST /api/v1/refresh",
-		apiCfg.postAPIRefresh,
+		userHandler.RefreshAccessToken,
 	)
 
 	log.Printf("Serving port : %v \n", serverPort)


### PR DESCRIPTION
This PR moves the refresh access token handler to the user api layer and adds an auth package for auth helper functions. This is not the final state but just speeds up decoupling the end state of the auth API package will be.
```
 /auth       
        /middleware.go
        /handlers.go
```

but for now the focus is decoupling the current user and url handlers