### PR TITLE
refactor: move update user handle to user api package

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"url-short/internal/database"
-	"url-short/internal/domain/user"
 )
 
 type apiConfig struct {
@@ -227,39 +226,5 @@ func (apiCfg *apiConfig) putShortURL(w http.ResponseWriter, r *http.Request, use
 	respondWithJSON(w, http.StatusOK, ShortURLUpdateResponse{
 		LongURL:  payload.LongURL,
 		ShortURL: query,
-	})
-}
-
-func (apiCfg *apiConfig) putAPIUsers(w http.ResponseWriter, r *http.Request, authUser database.User) {
-	payload := APIUserRequest{}
-
-	err := json.NewDecoder(r.Body).Decode(&payload)
-
-	if err != nil {
-		respondWithError(w, http.StatusBadRequest, "incorrect parameters for user update request")
-		return
-	}
-
-	domainUser, err := user.NewUser(payload.Email, payload.Password)
-	if err != nil {
-		log.Println(err)
-		respondWithError(w, http.StatusBadRequest, err.Error())
-	}
-	domainUser.SetID(authUser.ID)
-
-	err = apiCfg.DB.UpdateUser(r.Context(), database.UpdateUserParams{
-		Email:     domainUser.Email(),
-		Password:  domainUser.PasswordHash(),
-		ID:        domainUser.ID(),
-		UpdatedAt: time.Now(),
-	})
-
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "could not update user in database")
-	}
-
-	respondWithJSON(w, http.StatusOK, APIUserResponseNoToken{
-		Email: payload.Email,
-		ID:    domainUser.ID(),
 	})
 }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -449,21 +449,19 @@ func TestPutUser(t *testing.T) {
 
 	dbQueries := database.New(db)
 
-	apiCfg := apiConfig{
+	apiCfg := api.APIConfig{
 		DB: dbQueries,
 	}
 
-	userAPICfg := api.APIConfig{
-		DB: dbQueries,
-	}
+	userHandler := users.NewUserHandler(&apiCfg)
 
-	_, err = setupUserOne(&userAPICfg)
+	_, err = setupUserOne(&apiCfg)
 
 	if err != nil {
 		t.Errorf("can not set up user for test case with err %q", err)
 	}
 
-	userOne, err := loginUserOne(&userAPICfg)
+	userOne, err := loginUserOne(&apiCfg)
 
 	if err != nil {
 		t.Errorf("can not login user one for test case with err %q", err)
@@ -483,7 +481,7 @@ func TestPutUser(t *testing.T) {
 			t.Error("could not find user that was expected to exist")
 		}
 
-		apiCfg.putAPIUsers(putUserResponse, putUserRequest, user)
+		userHandler.UpdateUser(putUserResponse, putUserRequest, user)
 
 		gotPUTUser := APIUserResponseNoToken{}
 

--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 	)
 	mux.HandleFunc(
 		"PUT /api/v1/users",
-		apiCfg.authenticationMiddleware(apiCfg.putAPIUsers),
+		apiCfg.authenticationMiddleware(userHandler.UpdateUser),
 	)
 	mux.HandleFunc(
 		"POST /api/v1/login",


### PR DESCRIPTION
This PR moves the user update handler to the user API package in effort to star decoupling the API, service and repository layers. 