### PR TITLE
feat: move shorturl to its own domain

### DIFF
--- a/internal/domain/shorturl/main.go
+++ b/internal/domain/shorturl/main.go
@@ -1,10 +1,27 @@
-package shortener
+package shorturl
 
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"net/url"
 	"strings"
 )
+
+type ShortUrl struct {
+	ShortUrl *url.URL
+	LongUrl  *url.URL
+}
+
+func NewShortUrl(longUrl string) (*ShortUrl, error) {
+	parsed, err := url.ParseRequestURI(longUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ShortUrl{
+		LongUrl: parsed,
+	}, nil
+}
 
 const urlHashPostfix = "Xa1"
 

--- a/internal/domain/shorturl/main_test.go
+++ b/internal/domain/shorturl/main_test.go
@@ -1,4 +1,4 @@
-package shortener
+package shorturl
 
 import (
 	"crypto/md5"


### PR DESCRIPTION
This PR start to add a shortrul domain so we can now make API layer unaware of the shorturl implementation. 