### PR TITLE
refactor: migrate `DeleteShortURL` to use new service and repo layer functions. 

### DIFF
--- a/internal/domain/shorturl/main.go
+++ b/internal/domain/shorturl/main.go
@@ -53,6 +53,18 @@ func NewCreateURLRequest(userID int32, URL string) (*CreateURLRequest, error) {
 	}, nil
 }
 
+type DeleteURLRequest struct {
+	UserID   int32
+	ShortURL string
+}
+
+func NewDeleteURLRequest(userID int32, URL string) *DeleteURLRequest {
+	return &DeleteURLRequest{
+		UserID:   userID,
+		ShortURL: URL,
+	}
+}
+
 type URLError struct {
 	Code    string
 	Message string

--- a/internal/domain/user/main.go
+++ b/internal/domain/user/main.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"errors"
-	"log"
 	"net/mail"
 	"time"
 
@@ -26,7 +25,6 @@ func NewUser(email, password string) (*User, error) {
 
 	parsedEmail, err := mail.ParseAddress(email)
 	if err != nil {
-		log.Println(err)
 		return nil, errors.New("could not create user: invalid email")
 	}
 

--- a/internal/repository/url.go
+++ b/internal/repository/url.go
@@ -12,7 +12,7 @@ type URLRepository interface {
 	CreateShortURL(ctx context.Context, request shorturl.CreateURLRequest) (*shorturl.URL, error)
 	GetURLByHash(ctx context.Context, hash string) (*shorturl.URL, error)
 	// UpdateShortURL(ctx context.Context, url shorturl.UpdateURLRequest) error
-	// DeleteShortURL(ctx context.Context, url shorturl.DeleteURLRequest) error
+	DeleteShortURL(ctx context.Context, url shorturl.DeleteURLRequest) error
 }
 
 type PostgresURLRepository struct {
@@ -67,4 +67,17 @@ func (r *PostgresURLRepository) GetURLByHash(
 		UpdatedAt: res.UpdatedAt,
 		UserID:    res.UserID,
 	}, nil
+}
+
+func (r *PostgresURLRepository) DeleteShortURL(
+	ctx context.Context,
+	url shorturl.DeleteURLRequest,
+) error {
+	if err := r.db.DeleteURL(ctx, database.DeleteURLParams{
+		UserID:   url.UserID,
+		ShortUrl: url.ShortURL,
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/repository/url.go
+++ b/internal/repository/url.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"url-short/internal/database"
@@ -57,7 +56,6 @@ func (r *PostgresURLRepository) GetURLByHash(
 ) (*shorturl.URL, error) {
 	res, err := r.db.SelectURL(ctx, hash)
 	if err != nil {
-		log.Println(err)
 		return nil, err
 	}
 

--- a/internal/service/url.go
+++ b/internal/service/url.go
@@ -22,7 +22,7 @@ type URLService interface {
 	GenerateUniqueShortURL(ctx context.Context, longURL string) (string, error)
 	GetLongURL(ctx context.Context, shortURL string) (*shorturl.URL, error)
 	// UpdateShortURL(ctx context.Context, url shorturl.UpdateURLRequest) error
-	// DeleteShortURL(ctx context.Context, url shorturl.DeleteURLRequest) error
+	DeleteShortURL(ctx context.Context, url shorturl.DeleteURLRequest) error
 }
 
 type URLServiceImpl struct {
@@ -143,4 +143,11 @@ func (s *URLServiceImpl) GetLongURL(ctx context.Context, shortURL string) (*shor
 	}
 
 	return &shorturl.URL{LongURL: url}, nil
+}
+
+func (s *URLServiceImpl) DeleteShortURL(ctx context.Context, url shorturl.DeleteURLRequest) error {
+	if err := s.urlRepo.DeleteShortURL(ctx, url); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/transport/http/api/shorturls.go
+++ b/internal/transport/http/api/shorturls.go
@@ -83,21 +83,21 @@ func (h *shorturlHandler) GetShortURL(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, url.LongURL, http.StatusMovedPermanently)
 }
 
-func (handler *shorturlHandler) DeleteShortURL(w http.ResponseWriter, r *http.Request, user database.User) {
-	query := r.PathValue("shortUrl")
+func (h *shorturlHandler) DeleteShortURL(w http.ResponseWriter, r *http.Request, user database.User) {
+	shortUrl := r.PathValue("shortUrl")
 
-	if query == "" {
+	if shortUrl == "" {
 		respondWithError(w, http.StatusBadRequest, "no short url supplied")
 		return
 	}
 
-	err := handler.database.DeleteURL(r.Context(), database.DeleteURLParams{
-		UserID:   user.ID,
-		ShortUrl: query,
-	})
+	req := shorturl.NewDeleteURLRequest(user.ID, shortUrl)
+
+	err := h.urlService.DeleteShortURL(r.Context(), *req)
 
 	if err != nil {
 		log.Println(err)
+		// TODO: multiple errors could bubble up here handle them!
 		respondWithError(w, http.StatusBadRequest, "could not delete short url")
 		return
 	}


### PR DESCRIPTION
This PR will make use of the new architechure the API layer will call the service layer that will use the cacherepo and databaserepo for `DeleteShortURL`