### PR TITLE
chore: remove old database and cache access from url handler

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -58,7 +58,7 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 
 	users := api.NewUserHandler(a.DB, a.JWTSecret)
 	auth := api.NewAuthHandler(a.DB, a.JWTSecret)
-	urls := api.NewShortUrlHandler(a.DB, a.Cache, service)
+	urls := api.NewShortUrlHandler(service)
 
 	mux.HandleFunc("GET /api/v1/healthz", api.GetHealth)
 

--- a/internal/transport/http/api/shorturls.go
+++ b/internal/transport/http/api/shorturls.go
@@ -5,26 +5,17 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/redis/go-redis/v9"
-
 	"url-short/internal/database"
 	"url-short/internal/domain/shorturl"
 	"url-short/internal/service"
 )
 
 type shorturlHandler struct {
-	// temporary now to allow transport, service and repository layers to be decoupled
-	database *database.Queries
-	cache    *redis.Client
-	// this will be the final and ONLY field in the hanlder when I have moved to
-	// a layered architechure
 	urlService service.URLService
 }
 
-func NewShortUrlHandler(d *database.Queries, c *redis.Client, s service.URLService) *shorturlHandler {
+func NewShortUrlHandler(s service.URLService) *shorturlHandler {
 	return &shorturlHandler{
-		database:   d,
-		cache:      c,
 		urlService: s,
 	}
 }

--- a/internal/transport/http/api/shorturls_test.go
+++ b/internal/transport/http/api/shorturls_test.go
@@ -28,7 +28,7 @@ func TestPostLongURL(t *testing.T) {
 		t.Errorf("can not login user one for test case with err %q", err)
 	}
 
-	urls := NewShortUrlHandler(app.DB, app.Cache, app.Service)
+	urls := NewShortUrlHandler(app.Service)
 
 	t.Run("test user can create short URL based on long", func(t *testing.T) {
 		postLongURLRequest := httptest.NewRequest(http.MethodPost, "/api/v1/data/shorten", bytes.NewBuffer(LongUrl))
@@ -85,7 +85,7 @@ func TestGetShortURL(t *testing.T) {
 		t.Errorf("can not login user one for test case with err %q", err)
 	}
 
-	urls := NewShortUrlHandler(app.DB, app.Cache, app.Service)
+	urls := NewShortUrlHandler(app.Service)
 
 	postLongURLRequest := httptest.NewRequest(
 		http.MethodPost,


### PR DESCRIPTION
This PR cleans up all of the old code pre migration to layered architecture where the handlers had direct database access.  