### PR TITLE
feat: new user repo and service layers and refactor the api layer for the user handler to use service layer

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -53,12 +53,14 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 
 	databaseRepo := repository.NewPostgresURLRepository(dbQueries)
 	cacheRepo := repository.NewCacheRedis(redisClient)
+	userRepo := repository.NewPostgresUserRepository(dbQueries)
 
-	service := service.NewURLServiceImpl(databaseRepo, cacheRepo)
+	URLservice := service.NewURLServiceImpl(databaseRepo, cacheRepo)
+	UserService := service.NewUserServiceImpl(userRepo)
 
-	users := api.NewUserHandler(a.DB, a.JWTSecret)
+	users := api.NewUserHandler(a.DB, a.JWTSecret, UserService)
 	auth := api.NewAuthHandler(a.DB, a.JWTSecret)
-	urls := api.NewShortUrlHandler(service)
+	urls := api.NewShortUrlHandler(URLservice)
 
 	mux.HandleFunc("GET /api/v1/healthz", api.GetHealth)
 

--- a/internal/domain/user/main.go
+++ b/internal/domain/user/main.go
@@ -9,13 +9,13 @@ import (
 )
 
 type User struct {
-	id                     int32
-	email                  mail.Address
-	passwordHash           []byte
-	createdAt              time.Time
-	updatedAt              time.Time
-	refreshToken           string
-	refreshTokenRevokeDate time.Time
+	Id                     int32
+	Email                  string
+	PasswordHash           []byte
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
+	RefreshToken           string
+	RefreshTokenRevokeDate time.Time
 }
 
 func NewUser(email, password string) (*User, error) {
@@ -23,7 +23,7 @@ func NewUser(email, password string) (*User, error) {
 		return nil, errors.New("could not create user: empty email")
 	}
 
-	parsedEmail, err := mail.ParseAddress(email)
+	_, err := mail.ParseAddress(email)
 	if err != nil {
 		return nil, errors.New("could not create user: invalid email")
 	}
@@ -41,44 +41,30 @@ func NewUser(email, password string) (*User, error) {
 		return nil, errors.New("could not create user: failure to hash password")
 	}
 
-	now := time.Now()
-
 	return &User{
-		email:        *parsedEmail,
-		passwordHash: passwordHash,
-		createdAt:    now,
-		updatedAt:    now,
+		Email:        email,
+		PasswordHash: passwordHash,
 	}, nil
 }
 
-func (u *User) ID() int32 {
-	return u.id
+func (u *User) GetPasswordHash() string {
+	return string(u.PasswordHash)
 }
 
-func (u *User) SetID(id int32) {
-	u.id = id
+// TODO: Getters
+type CreateUserRequest struct {
+	Email        string
+	PasswordHash string
 }
 
-func (u *User) Email() string {
-	return u.email.Address
-}
+func NewCreateUserRequest(email, password string) (*CreateUserRequest, error) {
+	user, err := NewUser(email, password)
+	if err != nil {
+		return nil, err
+	}
 
-func (u *User) PasswordHash() string {
-	return string(u.passwordHash)
-}
-
-func (u *User) CreatedAt() time.Time {
-	return u.createdAt
-}
-
-func (u *User) UpdatedAt() time.Time {
-	return u.updatedAt
-}
-
-func (u *User) RefreshToken() string {
-	return u.refreshToken
-}
-
-func (u *User) RefreshTokenRevokeDate() time.Time {
-	return u.refreshTokenRevokeDate
+	return &CreateUserRequest{
+		Email:        user.Email,
+		PasswordHash: user.GetPasswordHash(),
+	}, nil
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"context"
+	"time"
+	"url-short/internal/database"
+	"url-short/internal/domain/user"
+)
+
+type UserRepository interface {
+	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
+}
+
+type PostgresUserRepository struct {
+	db *database.Queries
+}
+
+func NewPostgresUserRepository(db *database.Queries) *PostgresUserRepository {
+	return &PostgresUserRepository{
+		db: db,
+	}
+}
+
+func (r *PostgresUserRepository) CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error) {
+	now := time.Now()
+
+	res, err := r.db.CreateUser(ctx, database.CreateUserParams{
+		Email:     request.Email,
+		Password:  request.PasswordHash,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.User{
+		Id:           res.ID,
+		Email:        res.Email,
+		PasswordHash: []byte(res.Password),
+		CreatedAt:    res.CreatedAt,
+		UpdatedAt:    res.UpdatedAt,
+	}, nil
+}

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+
+	"url-short/internal/domain/user"
+	"url-short/internal/repository"
+)
+
+type UserService interface {
+	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
+	//UpdateUser()
+	//LoginUser()
+	//GetUserRefreshToken()
+}
+
+type UserServiceImpl struct {
+	userRepo repository.UserRepository
+}
+
+func NewUserServiceImpl(r repository.UserRepository) *UserServiceImpl {
+	return &UserServiceImpl{
+		userRepo: r,
+	}
+}
+
+func (s *UserServiceImpl) CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error) {
+	res, err := s.userRepo.CreateUser(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+
+}

--- a/internal/transport/http/api/users_test.go
+++ b/internal/transport/http/api/users_test.go
@@ -19,7 +19,7 @@ func TestPostUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
 
 	t.Run("test user creation passes with correct parameters", func(t *testing.T) {
 		userOne, err := setupUserOne(app)
@@ -115,7 +115,7 @@ func TestPostUser(t *testing.T) {
 			t.Errorf("unable to parse response %q into %q", response.Body, got)
 		}
 
-		want := "could not create user in database"
+		want := "could not create user"
 		if got.Error != want {
 			t.Errorf("expected duplicate user to fail got %q wanted %q", got.Error, want)
 		}
@@ -128,7 +128,7 @@ func TestPostLogin(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
 
 	_, err = setupUserOne(app)
 
@@ -230,7 +230,7 @@ func TestRefreshEndpoint(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
 
 	_, err = setupUserOne(app)
 
@@ -274,7 +274,7 @@ func TestPutUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
 
 	_, err = setupUserOne(app)
 


### PR DESCRIPTION
This PR aims to add

- New user repo layer for database access
- New service layer to seperate the transport protocol and internal application logic
- Migrate `CreateUser` to use the service layer for creating users and refactor tests

