### PR TITLE
refactor: migrate LoginUser API layer to use the new service and repo functions

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -56,7 +56,7 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 	userRepo := repository.NewPostgresUserRepository(dbQueries)
 
 	URLservice := service.NewURLServiceImpl(databaseRepo, cacheRepo)
-	UserService := service.NewUserServiceImpl(userRepo)
+	UserService := service.NewUserServiceImpl(userRepo, a.JWTSecret)
 
 	users := api.NewUserHandler(a.DB, a.JWTSecret, UserService)
 	auth := api.NewAuthHandler(a.DB, a.JWTSecret)

--- a/internal/domain/user/main.go
+++ b/internal/domain/user/main.go
@@ -14,6 +14,7 @@ type User struct {
 	PasswordHash           []byte
 	CreatedAt              time.Time
 	UpdatedAt              time.Time
+	Token                  string
 	RefreshToken           string
 	RefreshTokenRevokeDate time.Time
 }
@@ -66,5 +67,21 @@ func NewCreateUserRequest(email, password string) (*CreateUserRequest, error) {
 	return &CreateUserRequest{
 		Email:        user.Email,
 		PasswordHash: user.GetPasswordHash(),
+	}, nil
+}
+
+type LoginUserRequest struct {
+	Email    string
+	Password string
+}
+
+func NewLoginUserRequest(email, password string) (*LoginUserRequest, error) {
+	if email == "" || password == "" {
+		return nil, errors.New("email or password must not be empty")
+	}
+
+	return &LoginUserRequest{
+		Email:    email,
+		Password: password,
 	}, nil
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -2,13 +2,17 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"time"
+
 	"url-short/internal/database"
 	"url-short/internal/domain/user"
 )
 
 type UserRepository interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
+	SelectUser(ctx context.Context, email string) (*user.User, error)
+	UpdateRefreshToken(ctx context.Context, refreshToken string, userID int32) error
 }
 
 type PostgresUserRepository struct {
@@ -32,6 +36,7 @@ func (r *PostgresUserRepository) CreateUser(ctx context.Context, request user.Cr
 	})
 
 	if err != nil {
+		// This error hides not found and also internal server error when I have custom error types fix
 		return nil, err
 	}
 
@@ -42,4 +47,35 @@ func (r *PostgresUserRepository) CreateUser(ctx context.Context, request user.Cr
 		CreatedAt:    res.CreatedAt,
 		UpdatedAt:    res.UpdatedAt,
 	}, nil
+}
+
+func (r *PostgresUserRepository) SelectUser(ctx context.Context, email string) (*user.User, error) {
+	res, err := r.db.SelectUser(ctx, email)
+
+	// This error hides not found and also internal server error when I have custom error types fix
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.User{
+		Id:           res.ID,
+		Email:        res.Email,
+		PasswordHash: []byte(res.Password),
+		CreatedAt:    res.CreatedAt,
+		UpdatedAt:    res.UpdatedAt,
+	}, nil
+}
+
+func (r *PostgresUserRepository) UpdateRefreshToken(ctx context.Context, refreshToken string, userID int32) error {
+	err := r.db.UserTokenRefresh(ctx, database.UserTokenRefreshParams{
+		RefreshToken:           sql.NullString{String: refreshToken, Valid: true},
+		RefreshTokenRevokeDate: sql.NullTime{Time: time.Now().Add(60 * (24 * time.Hour)), Valid: true},
+		ID:                     userID,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -2,6 +2,13 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strconv"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
 
 	"url-short/internal/domain/user"
 	"url-short/internal/repository"
@@ -9,18 +16,21 @@ import (
 
 type UserService interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
+	LoginUser(ctx context.Context, request user.LoginUserRequest) (*user.User, error)
 	//UpdateUser()
 	//LoginUser()
 	//GetUserRefreshToken()
 }
 
 type UserServiceImpl struct {
-	userRepo repository.UserRepository
+	userRepo  repository.UserRepository
+	JWTSecret string
 }
 
-func NewUserServiceImpl(r repository.UserRepository) *UserServiceImpl {
+func NewUserServiceImpl(r repository.UserRepository, jwtSecret string) *UserServiceImpl {
 	return &UserServiceImpl{
-		userRepo: r,
+		userRepo:  r,
+		JWTSecret: jwtSecret,
 	}
 }
 
@@ -31,5 +41,47 @@ func (s *UserServiceImpl) CreateUser(ctx context.Context, request user.CreateUse
 	}
 
 	return res, nil
+}
 
+func (s *UserServiceImpl) LoginUser(ctx context.Context, request user.LoginUserRequest) (*user.User, error) {
+	user, err := s.userRepo.SelectUser(ctx, request.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	err = bcrypt.CompareHashAndPassword(user.PasswordHash, []byte(request.Password))
+	if err != nil {
+		return nil, err
+	}
+
+	registeredClaims := jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		Issuer:    "url-short-auth",
+		Subject:   strconv.Itoa(int(user.Id)),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, registeredClaims)
+
+	signedToken, err := token.SignedString([]byte(s.JWTSecret))
+	if err != nil {
+		return nil, err
+	}
+
+	byteSlice := make([]byte, 32)
+	_, err = rand.Read(byteSlice)
+	refreshToken := hex.EncodeToString(byteSlice)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.userRepo.UpdateRefreshToken(ctx, refreshToken, user.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	user.RefreshToken = refreshToken
+	user.Token = signedToken
+
+	return user, nil
 }

--- a/internal/transport/http/api/shorturls_test.go
+++ b/internal/transport/http/api/shorturls_test.go
@@ -28,7 +28,7 @@ func TestPostLongURL(t *testing.T) {
 		t.Errorf("can not login user one for test case with err %q", err)
 	}
 
-	urls := NewShortUrlHandler(app.Service)
+	urls := NewShortUrlHandler(app.URLService)
 
 	t.Run("test user can create short URL based on long", func(t *testing.T) {
 		postLongURLRequest := httptest.NewRequest(http.MethodPost, "/api/v1/data/shorten", bytes.NewBuffer(LongUrl))
@@ -47,7 +47,7 @@ func TestPostLongURL(t *testing.T) {
 		// As there are no hashes in the database there is no chance of a collision
 		// the first hash we generate here and the hash in the call to the handler will
 		// always be the same so we compare the two
-		hash, err := app.Service.GenerateUniqueShortURL(postLongURLRequest.Context(), "www.google.com")
+		hash, err := app.URLService.GenerateUniqueShortURL(postLongURLRequest.Context(), "www.google.com")
 
 		if err != nil {
 			t.Errorf("could not generate hash err %q", err)
@@ -85,7 +85,7 @@ func TestGetShortURL(t *testing.T) {
 		t.Errorf("can not login user one for test case with err %q", err)
 	}
 
-	urls := NewShortUrlHandler(app.Service)
+	urls := NewShortUrlHandler(app.URLService)
 
 	postLongURLRequest := httptest.NewRequest(
 		http.MethodPost,

--- a/internal/transport/http/api/users_test.go
+++ b/internal/transport/http/api/users_test.go
@@ -19,7 +19,7 @@ func TestPostUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
 
 	t.Run("test user creation passes with correct parameters", func(t *testing.T) {
 		userOne, err := setupUserOne(app)
@@ -128,7 +128,7 @@ func TestPostLogin(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
 
 	_, err = setupUserOne(app)
 
@@ -152,7 +152,7 @@ func TestPostLogin(t *testing.T) {
 			t.Errorf("could not parse response %q", err)
 		}
 
-		want := "invalid parameters for user login"
+		want := "email or password must not be empty"
 		if got.Error != want {
 			t.Errorf("incorrect error when passing invalid login parameters got %q want %q", got.Error, want)
 		}
@@ -174,7 +174,7 @@ func TestPostLogin(t *testing.T) {
 			t.Errorf("could not parse response %q", err)
 		}
 
-		want := "could not find user"
+		want := "could be lots of errors need to handle"
 		if got.Error != want {
 			t.Errorf("incorrect error when non existent user attempts to login got %q want %q", got.Error, want)
 		}
@@ -196,7 +196,7 @@ func TestPostLogin(t *testing.T) {
 			t.Errorf("could not parse response %q", err)
 		}
 
-		want := "invalid password"
+		want := "could be lots of errors need to handle"
 		if got.Error != want {
 			t.Errorf("incorrect error when incorrect password is supplied got %q want %q", got.Error, want)
 		}
@@ -230,7 +230,7 @@ func TestRefreshEndpoint(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
 
 	_, err = setupUserOne(app)
 
@@ -274,7 +274,7 @@ func TestPutUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserRepo)
+	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
 
 	_, err = setupUserOne(app)
 


### PR DESCRIPTION
This PR aims to: 

- Add new functionality to the user repo to select users by email and update a users refresh token 
- Add new functionality to the user service to login a user and handle JWT interactions 
- Migrate the LoginUser REST endpoint to use the new service layer