### PR TITLE
refactor: migrating refresh access token to use a new service and repo layer

### DIFF
--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -12,6 +12,7 @@ import (
 type UserRepository interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
 	SelectUser(ctx context.Context, email string) (*user.User, error)
+	SelectUserByRefreshToken(ctx context.Context, email string) (*user.User, error)
 	UpdateRefreshToken(ctx context.Context, refreshToken string, userID int32) error
 }
 
@@ -78,4 +79,20 @@ func (r *PostgresUserRepository) UpdateRefreshToken(ctx context.Context, refresh
 	}
 
 	return nil
+}
+
+func (r *PostgresUserRepository) SelectUserByRefreshToken(ctx context.Context, refreshToken string) (*user.User, error) {
+	res, err := r.db.SelectUserByRefreshToken(ctx, sql.NullString{String: refreshToken, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.User{
+		Id:                     res.ID,
+		Email:                  res.Email,
+		PasswordHash:           []byte(res.Password),
+		CreatedAt:              res.CreatedAt,
+		UpdatedAt:              res.UpdatedAt,
+		RefreshTokenRevokeDate: res.RefreshTokenRevokeDate.Time,
+	}, nil
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -90,6 +90,9 @@ func (s *UserServiceImpl) LoginUser(ctx context.Context, request user.LoginUserR
 
 func (s *UserServiceImpl) RefreshAccessToken(ctx context.Context, refreshToken string) (*user.User, error) {
 	user, err := s.userRepo.SelectUserByRefreshToken(ctx, refreshToken)
+	if err != nil {
+		return nil, err
+	}
 
 	if time.Now().After(user.RefreshTokenRevokeDate) {
 		return nil, errors.New("refresh token expired, please login again")

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"strconv"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 type UserService interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
 	LoginUser(ctx context.Context, request user.LoginUserRequest) (*user.User, error)
+	RefreshAccessToken(ctx context.Context, token string) (*user.User, error)
 	//UpdateUser()
 	//LoginUser()
 	//GetUserRefreshToken()
@@ -81,6 +83,33 @@ func (s *UserServiceImpl) LoginUser(ctx context.Context, request user.LoginUserR
 	}
 
 	user.RefreshToken = refreshToken
+	user.Token = signedToken
+
+	return user, nil
+}
+
+func (s *UserServiceImpl) RefreshAccessToken(ctx context.Context, refreshToken string) (*user.User, error) {
+	user, err := s.userRepo.SelectUserByRefreshToken(ctx, refreshToken)
+
+	if time.Now().After(user.RefreshTokenRevokeDate) {
+		return nil, errors.New("refresh token expired, please login again")
+	}
+
+	registeredClaims := jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
+		IssuedAt:  jwt.NewNumericDate(time.Now()),
+		Issuer:    "url-short-auth",
+		Subject:   strconv.Itoa(int(user.Id)),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, registeredClaims)
+
+	signedToken, err := token.SignedString([]byte(s.JWTSecret))
+
+	if err != nil {
+		return nil, err
+	}
+
 	user.Token = signedToken
 
 	return user, nil


### PR DESCRIPTION
This PR changes the following:
- Removes all JWT interaction from the API layer for `RefreshAccessToken` this is now handeled by the user service
- A new user service layer function for refreshing access tokens 
- A new repo layer function for getting a user by their refresh token