### PR TITLE
refactor: move UpdateUser to new service and repo layer and remove database and jwt secret from API layer for users

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -58,7 +58,7 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 	URLservice := service.NewURLServiceImpl(databaseRepo, cacheRepo)
 	UserService := service.NewUserServiceImpl(userRepo, a.JWTSecret)
 
-	users := api.NewUserHandler(a.DB, a.JWTSecret, UserService)
+	users := api.NewUserHandler(UserService)
 	auth := api.NewAuthHandler(a.DB, a.JWTSecret)
 	urls := api.NewShortUrlHandler(URLservice)
 

--- a/internal/domain/user/main.go
+++ b/internal/domain/user/main.go
@@ -85,3 +85,22 @@ func NewLoginUserRequest(email, password string) (*LoginUserRequest, error) {
 		Password: password,
 	}, nil
 }
+
+type UpdateUserRequest struct {
+	Id              int32
+	Email           string
+	NewPasswordHash string
+}
+
+func NewUpdateUserRequest(email, password string, userId int32) (*UpdateUserRequest, error) {
+	user, err := NewUser(email, password)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UpdateUserRequest{
+		Id:              userId,
+		Email:           user.Email,
+		NewPasswordHash: user.GetPasswordHash(),
+	}, nil
+}

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -14,6 +14,7 @@ type UserRepository interface {
 	SelectUser(ctx context.Context, email string) (*user.User, error)
 	SelectUserByRefreshToken(ctx context.Context, email string) (*user.User, error)
 	UpdateRefreshToken(ctx context.Context, refreshToken string, userID int32) error
+	UpdateUser(ctx context.Context, request user.UpdateUserRequest) (*user.User, error)
 }
 
 type PostgresUserRepository struct {
@@ -95,4 +96,24 @@ func (r *PostgresUserRepository) SelectUserByRefreshToken(ctx context.Context, r
 		UpdatedAt:              res.UpdatedAt,
 		RefreshTokenRevokeDate: res.RefreshTokenRevokeDate.Time,
 	}, nil
+}
+
+func (r *PostgresUserRepository) UpdateUser(ctx context.Context, request user.UpdateUserRequest) (*user.User, error) {
+	res, err := r.db.UpdateUser(ctx, database.UpdateUserParams{
+		Email:     request.Email,
+		Password:  request.NewPasswordHash,
+		ID:        request.Id,
+		UpdatedAt: time.Now(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.User{
+		Id:        res.ID,
+		Email:     res.Email,
+		UpdatedAt: res.UpdatedAt,
+	}, nil
+
 }

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -19,9 +19,7 @@ type UserService interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
 	LoginUser(ctx context.Context, request user.LoginUserRequest) (*user.User, error)
 	RefreshAccessToken(ctx context.Context, token string) (*user.User, error)
-	//UpdateUser()
-	//LoginUser()
-	//GetUserRefreshToken()
+	UpdateUser(ctx context.Context, request user.UpdateUserRequest) (*user.User, error)
 }
 
 type UserServiceImpl struct {
@@ -114,6 +112,15 @@ func (s *UserServiceImpl) RefreshAccessToken(ctx context.Context, refreshToken s
 	}
 
 	user.Token = signedToken
+
+	return user, nil
+}
+
+func (s *UserServiceImpl) UpdateUser(ctx context.Context, request user.UpdateUserRequest) (*user.User, error) {
+	user, err := s.userRepo.UpdateUser(ctx, request)
+	if err != nil {
+		return nil, err
+	}
 
 	return user, nil
 }

--- a/internal/transport/http/api/helpers_test.go
+++ b/internal/transport/http/api/helpers_test.go
@@ -172,7 +172,7 @@ func setupUserOne(a *testApplication) (*createUserHTTPResponseBody, error) {
 
 	response := httptest.NewRecorder()
 
-	userHandler := NewUserHandler(a.DB, a.JWTSecret, a.UserService)
+	userHandler := NewUserHandler(a.UserService)
 	userHandler.CreateUser(response, request)
 
 	got := createUserHTTPResponseBody{}
@@ -192,7 +192,7 @@ func loginUserOne(a *testApplication) (*loginUserHTTPResponseBody, error) {
 
 	loginResponse := httptest.NewRecorder()
 
-	userHandler := NewUserHandler(a.DB, a.JWTSecret, a.UserService)
+	userHandler := NewUserHandler(a.UserService)
 	userHandler.LoginUser(loginResponse, loginRequest)
 
 	loginGot := loginUserHTTPResponseBody{}

--- a/internal/transport/http/api/users_test.go
+++ b/internal/transport/http/api/users_test.go
@@ -19,7 +19,7 @@ func TestPostUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
+	userHandler := NewUserHandler(app.UserService)
 
 	t.Run("test user creation passes with correct parameters", func(t *testing.T) {
 		userOne, err := setupUserOne(app)
@@ -128,7 +128,7 @@ func TestPostLogin(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
+	userHandler := NewUserHandler(app.UserService)
 
 	_, err = setupUserOne(app)
 
@@ -230,7 +230,7 @@ func TestRefreshEndpoint(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
+	userHandler := NewUserHandler(app.UserService)
 
 	_, err = setupUserOne(app)
 
@@ -274,7 +274,7 @@ func TestPutUser(t *testing.T) {
 		t.Errorf("could not create test app %q", err)
 	}
 
-	userHandler := NewUserHandler(app.DB, app.JWTSecret, app.UserService)
+	userHandler := NewUserHandler(app.UserService)
 
 	_, err = setupUserOne(app)
 

--- a/sql/queries/users.sql
+++ b/sql/queries/users.sql
@@ -13,10 +13,11 @@ SELECT *
 FROM users
 WHERE id = $1;
 
--- name: UpdateUser :exec
+-- name: UpdateUser :one
 UPDATE users
 SET email = $1, password = $2, updated_at = $3
-WHERE id = $4;
+WHERE id = $4
+RETURNING *;
 
 -- name: UserTokenRefresh :exec
 UPDATE users


### PR DESCRIPTION
This PR aims to:
- Migrate `UpdateUser` to the new repo and service layers 
- Remove the use of the DB connection and JWT secret from the users handler, this is now all handled via the service layer. 