### PR TITLE
refactor: auth handler now uses the user service and repo

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -59,7 +59,7 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 	UserService := service.NewUserServiceImpl(userRepo, a.JWTSecret)
 
 	users := api.NewUserHandler(UserService)
-	auth := api.NewAuthHandler(a.DB, a.JWTSecret)
+	auth := api.NewAuthHandler(UserService)
 	urls := api.NewShortUrlHandler(URLservice)
 
 	mux.HandleFunc("GET /api/v1/healthz", api.GetHealth)

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -13,6 +13,7 @@ type UserRepository interface {
 	CreateUser(ctx context.Context, request user.CreateUserRequest) (*user.User, error)
 	SelectUser(ctx context.Context, email string) (*user.User, error)
 	SelectUserByRefreshToken(ctx context.Context, email string) (*user.User, error)
+	SelectUserByID(ctx context.Context, userID int32) (*user.User, error)
 	UpdateRefreshToken(ctx context.Context, refreshToken string, userID int32) error
 	UpdateUser(ctx context.Context, request user.UpdateUserRequest) (*user.User, error)
 }
@@ -55,6 +56,21 @@ func (r *PostgresUserRepository) SelectUser(ctx context.Context, email string) (
 	res, err := r.db.SelectUser(ctx, email)
 
 	// This error hides not found and also internal server error when I have custom error types fix
+	if err != nil {
+		return nil, err
+	}
+
+	return &user.User{
+		Id:           res.ID,
+		Email:        res.Email,
+		PasswordHash: []byte(res.Password),
+		CreatedAt:    res.CreatedAt,
+		UpdatedAt:    res.UpdatedAt,
+	}, nil
+}
+
+func (r *PostgresUserRepository) SelectUserByID(ctx context.Context, id int32) (*user.User, error) {
+	res, err := r.db.SelectUserByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/transport/http/api/shorturls.go
+++ b/internal/transport/http/api/shorturls.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"net/http"
 
-	"url-short/internal/database"
 	"url-short/internal/domain/shorturl"
+	"url-short/internal/domain/user"
 	"url-short/internal/service"
 )
 
@@ -28,7 +28,7 @@ type createShortURLHTTPResponseBody struct {
 	ShortURL string `json:"short_url"`
 }
 
-func (h *shorturlHandler) CreateShortURL(w http.ResponseWriter, r *http.Request, user database.User) {
+func (h *shorturlHandler) CreateShortURL(w http.ResponseWriter, r *http.Request, user *user.User) {
 	payload := createShortURLHTTPRequestBody{}
 
 	err := json.NewDecoder(r.Body).Decode(&payload)
@@ -37,7 +37,7 @@ func (h *shorturlHandler) CreateShortURL(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	createURLRequest, err := shorturl.NewCreateURLRequest(user.ID, payload.LongURL)
+	createURLRequest, err := shorturl.NewCreateURLRequest(user.Id, payload.LongURL)
 	if err != nil {
 		log.Println(err)
 		respondWithError(w, http.StatusBadRequest, "could not parse request URL")
@@ -73,7 +73,7 @@ func (h *shorturlHandler) GetShortURL(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, url.LongURL, http.StatusMovedPermanently)
 }
 
-func (h *shorturlHandler) DeleteShortURL(w http.ResponseWriter, r *http.Request, user database.User) {
+func (h *shorturlHandler) DeleteShortURL(w http.ResponseWriter, r *http.Request, user *user.User) {
 	shortUrl := r.PathValue("shortUrl")
 
 	if shortUrl == "" {
@@ -81,7 +81,7 @@ func (h *shorturlHandler) DeleteShortURL(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	req := shorturl.NewDeleteURLRequest(user.ID, shortUrl)
+	req := shorturl.NewDeleteURLRequest(user.Id, shortUrl)
 
 	err := h.urlService.DeleteShortURL(r.Context(), *req)
 
@@ -104,7 +104,7 @@ type updateShortURLHTTPResponseBody struct {
 	LongURL  string `json:"long_url"`
 }
 
-func (h *shorturlHandler) UpdateShortURL(w http.ResponseWriter, r *http.Request, user database.User) {
+func (h *shorturlHandler) UpdateShortURL(w http.ResponseWriter, r *http.Request, user *user.User) {
 	query := r.PathValue("shortUrl")
 
 	if query == "" {
@@ -120,7 +120,7 @@ func (h *shorturlHandler) UpdateShortURL(w http.ResponseWriter, r *http.Request,
 		respondWithError(w, http.StatusBadRequest, "invalid request body")
 	}
 
-	req := shorturl.NewUpdateURLRequest(user.ID, query, payload.LongURL)
+	req := shorturl.NewUpdateURLRequest(user.Id, query, payload.LongURL)
 
 	url, err := h.urlService.UpdateShortURL(r.Context(), *req)
 

--- a/internal/transport/http/api/shorturls_test.go
+++ b/internal/transport/http/api/shorturls_test.go
@@ -38,7 +38,7 @@ func TestPostLongURL(t *testing.T) {
 
 		response := httptest.NewRecorder()
 
-		user, err := app.DB.SelectUser(postLongURLRequest.Context(), userOne.Email)
+		user, err := app.UserRepo.SelectUser(postLongURLRequest.Context(), userOne.Email)
 
 		if err != nil {
 			t.Error("could not find user that was expected to exist")
@@ -98,7 +98,7 @@ func TestGetShortURL(t *testing.T) {
 
 	postURLResponse := httptest.NewRecorder()
 
-	user, err := app.DB.SelectUser(postLongURLRequest.Context(), userOne.Email)
+	user, err := app.UserRepo.SelectUser(postLongURLRequest.Context(), userOne.Email)
 	if err != nil {
 		t.Error("could not find user that was expected to exist")
 	}

--- a/internal/transport/http/api/users.go
+++ b/internal/transport/http/api/users.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"net/http"
 
-	"url-short/internal/database"
 	"url-short/internal/domain/user"
 	"url-short/internal/service"
 )
@@ -139,7 +138,7 @@ type updateUserHTTPResponseBody struct {
 	Email string `json:"email"`
 }
 
-func (handler *userHandler) UpdateUser(w http.ResponseWriter, r *http.Request, authUser database.User) {
+func (handler *userHandler) UpdateUser(w http.ResponseWriter, r *http.Request, authUser *user.User) {
 	payload := updateUserHTTPRequestBody{}
 
 	err := json.NewDecoder(r.Body).Decode(&payload)
@@ -149,7 +148,7 @@ func (handler *userHandler) UpdateUser(w http.ResponseWriter, r *http.Request, a
 		return
 	}
 
-	updateUserRequest, err := user.NewUpdateUserRequest(payload.Email, payload.Password, authUser.ID)
+	updateUserRequest, err := user.NewUpdateUserRequest(payload.Email, payload.Password, authUser.Id)
 	if err != nil {
 		log.Println(err)
 		respondWithError(w, http.StatusBadRequest, err.Error())

--- a/internal/transport/http/api/users_test.go
+++ b/internal/transport/http/api/users_test.go
@@ -296,7 +296,7 @@ func TestPutUser(t *testing.T) {
 
 		putUserResponse := httptest.NewRecorder()
 
-		user, err := app.DB.SelectUser(putUserRequest.Context(), userOne.Email)
+		user, err := app.UserRepo.SelectUser(putUserRequest.Context(), userOne.Email)
 
 		if err != nil {
 			t.Error("could not find user that was expected to exist")


### PR DESCRIPTION
This PR 
- Removes the injection of the database connection and JWT secret from the API layer
- Moves JWT validation to the user service (you could argue there needs to be a JWT service)
- The auth handler is no unaware of the database and JWTSecrets and simply calls the user service