### PR TITLE
feat: add server timeouts

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -3,6 +3,7 @@ package application
 import (
 	"database/sql"
 	"net/http"
+	"time"
 
 	_ "github.com/lib/pq"
 
@@ -33,8 +34,11 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 	mux := http.NewServeMux()
 
 	server := &http.Server{
-		Addr:    ":" + s.Server.Port,
-		Handler: mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  120 * time.Second,
+		Addr:         ":" + s.Server.Port,
+		Handler:      mux,
 	}
 
 	opt, err := redis.ParseURL(s.Cache.GetCacheURL())


### PR DESCRIPTION
Currently `r.Context()` only handles the case where the client kills the connection by sending a TCP FIN/RST or the server is shutting down this means that before these changes a client could technically have a handler hang forever processing a request. This could waste server resources and unintentionally take out the service. 

The changes below ensure that large request bodies have a timeout on read and handlers have a maximum time in witch they can execute. Finally `IdleTimeout` allows for a potential UI to make use of multiple HTTP requests without the overhead of establishing a TCP connection. 