### PR TITLE
feat: add correct created at and updated at to short url creation and correct RESTful violations

### DIFF
--- a/internal/application/main.go
+++ b/internal/application/main.go
@@ -70,19 +70,19 @@ func NewApplication(s *configuration.ApplicationSettings) (*Application, error) 
 
 	// url management endpoints
 	mux.HandleFunc(
-		"POST /api/v1/data/shorten",
+		"POST /api/v1/urls",
 		auth.AuthenticationMiddleware(urls.CreateShortURL),
 	)
 	mux.HandleFunc(
-		"GET /api/v1/{shortUrl}",
+		"GET /api/v1/urls/{shortUrl}",
 		urls.GetShortURL,
 	)
 	mux.HandleFunc(
-		"DELETE /api/v1/{shortUrl}",
+		"DELETE /api/v1/urls/{shortUrl}",
 		auth.AuthenticationMiddleware(urls.DeleteShortURL),
 	)
 	mux.HandleFunc(
-		"PUT /api/v1/{shortUrl}",
+		"PUT /api/v1/urls{shortUrl}",
 		auth.AuthenticationMiddleware(urls.UpdateShortURL),
 	)
 

--- a/internal/transport/http/api/shorturls.go
+++ b/internal/transport/http/api/shorturls.go
@@ -26,7 +26,9 @@ type createShortURLHTTPRequestBody struct {
 }
 
 type createShortURLHTTPResponseBody struct {
-	ShortURL string `json:"short_url"`
+	ShortURL  string    `json:"short_url"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 func (h *shorturlHandler) CreateShortURL(w http.ResponseWriter, r *http.Request, user *user.User) {
@@ -54,7 +56,9 @@ func (h *shorturlHandler) CreateShortURL(w http.ResponseWriter, r *http.Request,
 	}
 
 	respondWithJSON(w, http.StatusCreated, createShortURLHTTPResponseBody{
-		ShortURL: createURLResponse.ShortURL,
+		ShortURL:  createURLResponse.ShortURL,
+		CreatedAt: createURLResponse.CreatedAt,
+		UpdatedAt: createURLResponse.UpdatedAt,
 	})
 }
 

--- a/internal/transport/http/api/shorturls_test.go
+++ b/internal/transport/http/api/shorturls_test.go
@@ -32,7 +32,7 @@ func TestPostLongURL(t *testing.T) {
 	urls := NewShortUrlHandler(app.URLService)
 
 	t.Run("test user can create short URL based on long", func(t *testing.T) {
-		postLongURLRequest := httptest.NewRequest(http.MethodPost, "/api/v1/data/shorten", bytes.NewBuffer(LongUrl))
+		postLongURLRequest := httptest.NewRequest(http.MethodPost, "/api/v1/urls", bytes.NewBuffer(LongUrl))
 
 		buildHeader := fmt.Sprintf("Bearer %s", userOne.RefreshToken)
 		postLongURLRequest.Header.Set("Authorization", buildHeader)
@@ -162,7 +162,7 @@ func TestUpdateShortURL(t *testing.T) {
 
 	postLongURLRequest := httptest.NewRequest(
 		http.MethodPost,
-		"/api/v1/data/shorten",
+		"/api/v1/urls",
 		bytes.NewBuffer(LongUrl),
 	)
 
@@ -189,7 +189,7 @@ func TestUpdateShortURL(t *testing.T) {
 		now := time.Now()
 		request, _ := http.NewRequest(
 			http.MethodPut,
-			fmt.Sprintf("/api/v1/%s", gotPutLongURL.ShortURL),
+			fmt.Sprintf("/api/v1/urls/%s", gotPutLongURL.ShortURL),
 			bytes.NewBuffer(LongUrl),
 		)
 		request.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
HTTP response structs do not contain important metadata like created at and updated at. There are also some restful violations in routes. 